### PR TITLE
Fix Docker environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ docker run --rm -it \
   -v "$(pwd)/creds:/creds:ro" \
   ghcr.io/schlomo/github-backup-app:latest \
   --app-id $(cat ./creds/*-app-id.txt) \
-  --private-key ./creds/$(ls ./creds/*-private-key.pem | head -1 | xargs basename) \
+  --private-key /creds/$(ls ./creds/*-private-key.pem | head -1 | xargs basename) \
   --all \
   --output-directory /data
 ```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ docker run --rm -it \
   -p 3000:3000 \
   -v "$(pwd)/creds:/creds" \
   ghcr.io/schlomo/github-backup-app:latest \
+  --host 0.0.0.0 \
   /creds
 ```
 This will:

--- a/github_backup/create_github_app.py
+++ b/github_backup/create_github_app.py
@@ -756,6 +756,9 @@ from your OS username. You can change this in the web interface if desired.
         help="Directory to save the app credentials (App ID, private key, client secret)",
     )
     parser.add_argument(
+        "--host", default="127.0.0.1", help="Host to bind to (default: localhost)"
+    )
+    parser.add_argument(
         "--port", type=int, default=3000, help="Port for the web server (default: 3000)"
     )
 
@@ -800,7 +803,7 @@ from your OS username. You can change this in the web interface if desired.
         # Use Werkzeug directly to avoid Flask startup messages
         from werkzeug.serving import make_server
 
-        server = make_server("localhost", args.port, app, threaded=True)
+        server = make_server(args.host, args.port, app, threaded=True)
         server.serve_forever()
 
     except KeyboardInterrupt:


### PR DESCRIPTION
I've tested the whole process, including the guided GitHub app setup, on my personal account. There were two minor issues, that I needed to fix for the **Docker** environment to work: 

- The process needs to bind to `0.0.0.0` when run inside Docker. Otherwise, port forwarding won't work. 
- The argument of the Docker command should take credentials location as an absolute path inside
Docker, as the CWD is set to `/data`.

Now it works like a charm! 🎉 I will test it on an actual org account in the following week.

